### PR TITLE
add publish with groupId

### DIFF
--- a/lib/SQSEventEmitterMQ.js
+++ b/lib/SQSEventEmitterMQ.js
@@ -12,9 +12,9 @@ class Publisher {
   publish(channel, message) {
     let payload;
     if (Array.isArray(message)) {
-      payload = message.map((body, index) => ({ id: index.toString(), body }));
+      payload = message.map((body, index) => Object.assign({ id: index.toString(), body }, channel ? { groupId: channel } : {}));
     } else {
-      payload = { id: '0', body: message };
+      payload = Object.assign({ id: 0, body: message }, channel ? { groupId: channel } : {});
     }
 
     this.emitter.send(payload, (err) => {

--- a/spec/SQSEventEmitterMQ.spec.js
+++ b/spec/SQSEventEmitterMQ.spec.js
@@ -107,6 +107,17 @@ describe('SMSEventEmitterMQ', () => {
       spyOn(publisher.emitter, 'send');
       publisher.publish('channel', ['foo', 'bar']);
       const payload = [
+        { id: '0', body: 'foo', groupId: 'channel' },
+        { id: '1', body: 'bar', groupId: 'channel' },
+      ];
+      expect(publisher.emitter.send).toHaveBeenCalledWith(payload, jasmine.any(Function));
+    });
+
+    it('should process a batch with no channel', () => {
+      const publisher = ParseMessageQueue.createPublisher(config);
+      spyOn(publisher.emitter, 'send');
+      publisher.publish(undefined, ['foo', 'bar']);
+      const payload = [
         { id: '0', body: 'foo' },
         { id: '1', body: 'bar' },
       ];


### PR DESCRIPTION
Allow publishing with groupId, adding a minimal support to FIFO queues (deduplicationId is required only when content-based deduplication is disabled).