### PR TITLE
refactor: Bump parse-server from 9.9.0 to 9.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "jasmine-spec-reporter": "7.0.0",
         "mongodb-runner": "6.7.3",
         "nyc": "18.0.0",
-        "parse-server": "9.9.0",
+        "parse-server": "9.10.0",
         "semantic-release": "25.0.3"
       },
       "engines": {
@@ -12184,9 +12184,9 @@
       }
     },
     "node_modules/parse-server": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/parse-server/-/parse-server-9.9.0.tgz",
-      "integrity": "sha512-r3MpxphR40G7Jgpb4H40ElXj4bEoC/5WNV3hqE13+XZG7ZLl6pATEzF6GjQwvM2421m2MHsvqGl34BxsVtURqg==",
+      "version": "9.10.0",
+      "resolved": "https://registry.npmjs.org/parse-server/-/parse-server-9.10.0.tgz",
+      "integrity": "sha512-f4IIsWLsh30mOJl6u6SB3GBrj7Zj4f69dKkI0PPZxNeVttlKFBEg/VHc2AQrWKWRvnIlWy22o2UdX4ECPDPCIw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "jasmine-spec-reporter": "7.0.0",
     "mongodb-runner": "6.7.3",
     "nyc": "18.0.0",
-    "parse-server": "9.9.0",
+    "parse-server": "9.10.0",
     "semantic-release": "25.0.3"
   },
   "scripts": {


### PR DESCRIPTION
Closes #407

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development tooling to Parse Server version 9.10.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->