### PR TITLE
refactor: Bump semantic-release from 25.0.3 to 25.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "mongodb-runner": "6.7.3",
         "nyc": "18.0.0",
         "parse-server": "9.10.0",
-        "semantic-release": "25.0.3"
+        "semantic-release": "25.0.8"
       },
       "engines": {
         "node": ">=20.18.0 <21.0.0 || >=22.12.0 <23.0.0 || >=24.0.0 <25.0.0"
@@ -13394,10 +13394,11 @@
       "license": "MIT"
     },
     "node_modules/semantic-release": {
-      "version": "25.0.3",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.3.tgz",
-      "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
+      "version": "25.0.8",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.8.tgz",
+      "integrity": "sha512-w/iZ0bur36rKffXZYmIUmy068eoBY3Ij1DCCddx2JwWEM5Tg+eU9ld/E9qSInVvPASyyR2Ln/XGfQ9OZrMlhtw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "mongodb-runner": "6.7.3",
     "nyc": "18.0.0",
     "parse-server": "9.10.0",
-    "semantic-release": "25.0.3"
+    "semantic-release": "25.0.8"
   },
   "scripts": {
     "lint": "eslint --cache ./index.js ./lib/** ./spec/**/*.js",


### PR DESCRIPTION
Closes #403

## Summary
Bumps the direct devDependency `semantic-release` from `25.0.3` to `25.0.8` (routine patch update).

## Details
- Type: direct devDependency
- Change: patch bump `25.0.3` → `25.0.8`
- Scope: `package.json` and `package-lock.json` only; lockfile changes are confined to the `semantic-release` subtree.

## Notes
This is a replacement PR for the Dependabot PR #403, opened with a non-bot commit so it can be squash-merged under the maintainer identity.
