### PR TITLE
refactor: Bump jasmine from 6.2.0 to 6.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@semantic-release/release-notes-generator": "14.1.0",
         "eslint": "10.7.0",
         "globals": "17.5.0",
-        "jasmine": "6.2.0",
+        "jasmine": "6.3.0",
         "jasmine-spec-reporter": "7.0.0",
         "mongodb-runner": "6.7.3",
         "nyc": "18.0.0",
@@ -8773,24 +8773,24 @@
       }
     },
     "node_modules/jasmine": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-6.2.0.tgz",
-      "integrity": "sha512-dvYt7bidcu0JvvSbiUnSDW7UQQiflUwDr6C+5wzoZ0J7RY9u+UcoSIzyhMPj6fnU/tC7KinJ5QrjwD2Y9p4T4w==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-6.3.0.tgz",
+      "integrity": "sha512-u6L7yYtrtS1JALlp7f4k7Wz7o7ZKXauSKKkXc0L3qUkKrdaxYvNiMHhHp5gtTuVZZXVihXRxS7bWwDBX1wJ7EQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jasminejs/reporters": "^1.0.0",
         "glob": "^10.2.2 || ^11.0.3 || ^12.0.0 || ^13.0.0",
-        "jasmine-core": "~6.2.0"
+        "jasmine-core": "~6.3.0"
       },
       "bin": {
         "jasmine": "bin/jasmine.js"
       }
     },
     "node_modules/jasmine-core": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-6.2.0.tgz",
-      "integrity": "sha512-b16WZG/pFEFj8qRW1ss7nDuNGYz9ji8BDGj7fJNrROauk5rj/diO3KPOuyIpcgUChdC+c0PfQ8iUk4nHE+EN4w==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-6.3.0.tgz",
+      "integrity": "sha512-eMm5qBovNjNoGOcgE/W207+wrcK5zrQv0Rg/rWGboUJUmZp0dFCpHTyjpuDAfCwRCqg7f9U2q2jtv/aUuzdCQg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@semantic-release/release-notes-generator": "14.1.0",
     "eslint": "10.7.0",
     "globals": "17.5.0",
-    "jasmine": "6.2.0",
+    "jasmine": "6.3.0",
     "jasmine-spec-reporter": "7.0.0",
     "mongodb-runner": "6.7.3",
     "nyc": "18.0.0",


### PR DESCRIPTION
Closes #415

## Changes
Bumps the `jasmine` devDependency from 6.2.0 to 6.3.0. This is a routine minor version bump of the test framework. `jasmine-core` is updated to `~6.3.0` accordingly in the lockfile.

## Breaking Changes
None. Minor version bump of a devDependency used only for running the test suite; no runtime or published-package impact.

## Code Changes
None required. Only `package.json` and `package-lock.json` are updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Jasmine development tooling to version 6.3.0.
  * Refreshed the locked dependency metadata to match the updated version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->