### PR TITLE
refactor: Bump globals from 17.5.0 to 17.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@semantic-release/npm": "13.1.5",
         "@semantic-release/release-notes-generator": "14.1.0",
         "eslint": "10.7.0",
-        "globals": "17.5.0",
+        "globals": "17.7.0",
         "jasmine": "6.3.0",
         "jasmine-spec-reporter": "7.0.0",
         "mongodb-runner": "6.7.3",
@@ -7748,9 +7748,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.5.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
-      "integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@semantic-release/npm": "13.1.5",
     "@semantic-release/release-notes-generator": "14.1.0",
     "eslint": "10.7.0",
-    "globals": "17.5.0",
+    "globals": "17.7.0",
     "jasmine": "6.3.0",
     "jasmine-spec-reporter": "7.0.0",
     "mongodb-runner": "6.7.3",


### PR DESCRIPTION
Closes #416

## Summary
Bumps the direct devDependency `globals` from `17.5.0` to `17.7.0`.

## Details
- Replacement PR for Dependabot #416, authored from a fork branch.
- Manifest and lockfile only; lockfile change is confined to the `globals` subtree (version, resolved URL, integrity). `lockfileVersion: 3` preserved.

## Release notes
- https://github.com/sindresorhus/globals/releases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the development tooling dependency `globals` from version **17.5.0** to **17.7.0**.
  * Refreshed dependency lockfile metadata to match the updated version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->